### PR TITLE
Consistant (pseudo-)randomization in RandomBinaryProjections and RandomDiscretizedProjections

### DIFF
--- a/nearpy/hashes/randombinaryprojections.py
+++ b/nearpy/hashes/randombinaryprojections.py
@@ -34,7 +34,7 @@ class RandomBinaryProjections(LSHash):
     for storage.
     """
 
-    def __init__(self, hash_name, projection_count):
+    def __init__(self, hash_name, projection_count, rand_seed=None):
         """
         Creates projection_count random vectors, that are used for projections
         thus working as normals of random hyperplanes. Each random vector /
@@ -47,11 +47,12 @@ class RandomBinaryProjections(LSHash):
         self.projection_count = projection_count
         self.dim = None
         self.normals = None
+	self.rand = numpy.random.RandomState(rand_seed)
 
     def reset(self, dim):
         """ Resets / Initializes the hash for the specified dimension. """
         self.dim = dim
-        self.normals = numpy.random.randn(self.projection_count, dim)
+        self.normals = self.rand.randn(self.projection_count, dim)
 
     def hash_vector(self, v):
         """

--- a/nearpy/hashes/randomdiscretizedprojections.py
+++ b/nearpy/hashes/randomdiscretizedprojections.py
@@ -32,7 +32,7 @@ class RandomDiscretizedProjections(LSHash):
     random vector using a bin width.
     """
 
-    def __init__(self, hash_name, projection_count, bin_width):
+    def __init__(self, hash_name, projection_count, bin_width, rand_seed=None):
         """
         Creates projection_count random vectors, that are used for projections.
         Each random vector will result in one discretized coordinate.
@@ -45,11 +45,12 @@ class RandomDiscretizedProjections(LSHash):
         self.dim = None
         self.vectors = None
         self.bin_width = bin_width
+	self.rand = numpy.random.RandomState(rand_seed)
 
     def reset(self, dim):
         """ Resets / Initializes the hash for the specified dimension. """
         self.dim = dim
-        self.vectors = numpy.random.randn(self.projection_count, dim)
+        self.vectors = self.rand.randn(self.projection_count, dim)
 
     def hash_vector(self, v):
         """


### PR DESCRIPTION
Motive: Sometimes it is desired to have stable behaviour when using random projections. The current API does not allow to set a seed for the _RandomBinaryProjections_ and\* RandomDiscretizedProjections*.

Solution: I added an extra parameter to the constructor of these objects called 'rand_seed' that defaults to a value that replicates the current behaviour of these classes. This parameter can be set to a seed value (see [here](http://docs.scipy.org/doc/numpy/reference/generated/numpy.random.RandomState.html) for more info) that allows for consistent behaviour. This addition is backwards compatible with the current API.

I will be more than happy to make any extra modifications if needed.
