### PR TITLE
Manhattan distance function

### DIFF
--- a/nearpy/distances/manhattan.py
+++ b/nearpy/distances/manhattan.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2013 Ole Krause-Sparmann
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import numpy
+
+from nearpy.distances.distance import Distance
+
+
+class ManhattanDistance(Distance):
+    """ Manhattan distance """
+
+    def distance(self, x, y):
+        """
+        Computes the Manhattan distance between vectors x and y. Returns float.
+        """
+        return numpy.sum(numpy.absolute(x-y))
+


### PR DESCRIPTION
I created the file _distances/manhattan.py_ that implements the [Manhattan distance function](http://en.wikipedia.org/wiki/Taxicab_geometry).
I needed it for my own work, but thought it might be useful to the NearPy library in general.
Let me know if anything needs to be changed or added.
