### PR TITLE
Removed mutable default arguments

### DIFF
--- a/nearpy/engine.py
+++ b/nearpy/engine.py
@@ -54,14 +54,18 @@ class Engine(object):
                 tuples.
     """
 
-    def __init__(self, dim, lshashes=[RandomBinaryProjections('default', 10)],
-                 distance=EuclideanDistance(),
-                 vector_filters=[NearestFilter(10)],
-                 storage=MemoryStorage()):
+    def __init__(self, dim, lshashes=None,
+                 distance=None,
+                 vector_filters=None,
+                 storage=None):
         """ Keeps the configuration. """
+        if lshashes is None: lshashes = [RandomBinaryProjections('default', 10)]
         self.lshashes = lshashes
+        if distance is None: distance = EuclideanDistance()
         self.distance = distance
+        if vector_filters is None: vector_filters = [NearestFilter(10)]
         self.vector_filters = vector_filters
+        if storage is None: storage = MemoryStorage()
         self.storage = storage
 
         # Initialize all hashes for the data space dimension.


### PR DESCRIPTION
The default arguments of the `Engine` `__init__` function were mutable.
That means, they are shared across all instances of Engine.
See [here](http://eli.thegreenplace.net/2009/01/16/python-insight-beware-of-mutable-default-values-for-arguments) for details on this property of python.

I noticed this when creating multiple instances of `Engine`.
Since I didn't specify any argument for `storage`, it defaulted to `MemoryStorage()`.
Because `MemoryStorage()` is specified in the function arguments there was only one storage instance shared by all the engines that I created. 
Every time I queried nearest neighbors, they were retrieved from all the datasets in all my engines, the datasets were not separated as I intended.

I added a quick fix following a style that is recommended by most articles about the mutual default argument matter.
