### PR TITLE
Fix load_hash_configuration() to handle non-existent hash config

### DIFF
--- a/nearpy/storage/storage_memory.py
+++ b/nearpy/storage/storage_memory.py
@@ -80,5 +80,5 @@ class MemoryStorage(Storage):
         """
         Loads and returns hash configuration
         """
-        return self.hash_configs[hash_name]
+        return self.hash_configs.get(hash_name)
 

--- a/nearpy/storage/storage_redis.py
+++ b/nearpy/storage/storage_redis.py
@@ -154,5 +154,7 @@ class RedisStorage(Storage):
         """
         Loads and returns hash configuration
         """
-        return pickle.loads(self.redis_object.get(hash_name+'_conf'))
+        conf = self.redis_object.get(hash_name+'_conf')
+
+        return pickle.loads(conf) if conf is not None else None
 

--- a/nearpy/tests/hash_storage_tests.py
+++ b/nearpy/tests/hash_storage_tests.py
@@ -41,6 +41,11 @@ class TestHashStorage(unittest.TestCase):
                                   port=6379, db=0)
         self.redis_storage = RedisStorage(self.redis_object)
 
+    def test_hash_memory_storage_none_config(self):
+        conf = self.memory.load_hash_configuration('nonexistentHash')
+
+        self.assertIsNone(conf)
+
     def test_hash_memory_storage_rbp(self):
         hash1 = RandomBinaryProjections('testRBPHash', 10)
         hash1.reset(100)
@@ -112,6 +117,11 @@ class TestHashStorage(unittest.TestCase):
             for j in range(hash1.components.shape[1]):
                 self.assertEqual(hash1.components[i, j], hash2.components[i, j])
 
+
+    def test_hash_redis_storage_none_config(self):
+        conf = self.redis_storage.load_hash_configuration('nonexistentHash')
+
+        self.assertIsNone(conf)
 
     def test_hash_redis_storage_rbp(self):
         hash1 = RandomBinaryProjections('testRBPHash', 10)


### PR DESCRIPTION
Currently an exception occurs when we trying to get a non-existent hash configuration from the storage (no matters Redis or memory), e.g.

```
>>> redis_object = Redis(host='redis', port=6379, db=0)
>>> redis_storage = RedisStorage(redis_object)
>>> config = redis_storage.load_hash_configuration('MyHash')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python2.7/dist-packages/nearpy/storage/storage_redis.py", line 157, in load_hash_configuration
    return pickle.loads(self.redis_object.get(hash_name+'_conf'))
  File "/usr/lib/python2.7/pickle.py", line 1381, in loads
    file = StringIO(str)
TypeError: expected read buffer, NoneType found
```

```
>>> memory_storage = MemoryStorage()
>>> config = memory_storage.load_hash_configuration('MyHash')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python2.7/dist-packages/nearpy/storage/storage_memory.py", line 83, in load_hash_configuration
    return self.hash_configs[hash_name]
KeyError: 'MyHash'
```

This PR fixes such behavior and adds additional tests.
