### PR TITLE
Change to setuptools for install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 
 setup(
     name='NearPy',


### PR DESCRIPTION
`distutil` dooes not support `install_requires` and gives `UserWarning: Unknown distribution option: 'install_requires'`