### PR TITLE
Py3 compatibility fixes (Refs: #6)

### DIFF
--- a/nearpy/hashes/permutation/permute.py
+++ b/nearpy/hashes/permutation/permute.py
@@ -25,6 +25,7 @@ import random
 #from bitarray import bitarray
 from bisect import bisect_left
 
+from past.builtins import xrange
 
 class Permute:
 
@@ -38,7 +39,7 @@ class Permute:
         """
         Init a Permute object. Randomly generate a mapping, e.g. [0,1,2] -> [1,0,2]
         """
-        m = range(n)
+        m = list(range(n))
         for end in xrange(n - 1, 0, -1):
             r = random.randint(0, end)
             tmp = m[end]
@@ -78,8 +79,9 @@ class Permute:
         # binary search (pba,ba) in bas
         idx = bisect_left(bas, (pba, ba))
 
-        start = max(0, idx - half_beam)
-        end = min(len(bas), idx + half_beam)
+        start = int(max(0, idx - half_beam))
+        end = int(min(len(bas), idx + half_beam))
+
         res = bas[start:end]
 
         # return the original(unpermuted) keys

--- a/nearpy/tests/distances_tests.py
+++ b/nearpy/tests/distances_tests.py
@@ -30,7 +30,8 @@ from nearpy.distances import EuclideanDistance, CosineDistance, ManhattanDistanc
 
 # Helper functions
 
-def test_distance_symmetry(test_obj, distance):
+
+def check_distance_symmetry(test_obj, distance):
     for k in range(100):
         x = numpy.random.randn(10)
         y = numpy.random.randn(10)
@@ -49,7 +50,8 @@ def test_distance_symmetry(test_obj, distance):
         # I had precision issues with a local install. This test is more tolerant to that.
         test_obj.assertAlmostEqual(d_xy, d_yx, delta=0.00000000000001)
 
-def test_distance_triangle_inequality(test_obj, distance):
+
+def check_distance_triangle_inequality(test_obj, distance):
     for k in range(100):
         x = numpy.random.randn(10)
         y = numpy.random.randn(10)
@@ -81,10 +83,10 @@ class TestEuclideanDistance(unittest.TestCase):
         self.euclidean = EuclideanDistance()
 
     def test_triangle_inequality(self):
-        test_distance_triangle_inequality(self, self.euclidean)
+        check_distance_triangle_inequality(self, self.euclidean)
 
     def test_symmetry(self):
-        test_distance_symmetry(self, self.euclidean)
+        check_distance_symmetry(self, self.euclidean)
 
 class TestCosineDistance(unittest.TestCase):
 
@@ -92,7 +94,7 @@ class TestCosineDistance(unittest.TestCase):
         self.cosine = CosineDistance()
 
     def test_symmetry(self):
-        test_distance_symmetry(self, self.cosine)
+        check_distance_symmetry(self, self.cosine)
 
 class TestManhattanDistance(unittest.TestCase):
 
@@ -100,10 +102,10 @@ class TestManhattanDistance(unittest.TestCase):
         self.manhattan = ManhattanDistance()
 
     def test_triangle_inequality(self):
-        test_distance_triangle_inequality(self, self.manhattan)
+        check_distance_triangle_inequality(self, self.manhattan)
 
     def test_symmetry(self):
-        test_distance_symmetry(self, self.manhattan)
+        check_distance_symmetry(self, self.manhattan)
 
 if __name__ == '__main__':
     unittest.main()

--- a/nearpy/tests/permutation_tests.py
+++ b/nearpy/tests/permutation_tests.py
@@ -30,6 +30,8 @@ from nearpy.distances import CosineDistance
 from nearpy.hashes import HashPermutations
 from nearpy.hashes import RandomBinaryProjections
 
+from past.builtins import xrange
+
 
 class TestPermutation(unittest.TestCase):
 

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,6 @@ setup(
         "numpy",
         "scipy",
         "bitarray",
-        'mockredispy'
+        "future",
     ],
 )


### PR DESCRIPTION
Fixes to make all tests pass on Python 3.3 and 3.4. 