### PR TITLE
Testing against multiple python versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ pip-log.txt
 # Unit test / coverage reports
 .coverage
 .tox
+.eggs
+.cache
 nosetests.xml
 
 # Translations

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: python
+sudo: false
+python:
+  - "2.7"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+install:
+  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+      wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
+    else
+      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+    fi
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - hash -r
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  - conda info -a
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION NumPy SciPy
+  - source activate test-environment
+script:
+  - python setup.py test

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,7 +1,9 @@
+#! /usr/bin/env python
+import subprocess
 
-import unittest
+def main():
+    errno = subprocess.call(['py.test'])
+    raise SystemExit(errno)
 
-import nearpy.tests as tests
-
-suite = unittest.TestLoader().loadTestsFromModule(tests)
-unittest.TextTestRunner(verbosity=2).run(suite)
+if __name__ == '__main__':
+    main()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[aliases]
+test=pytest

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,24 @@
 #!/usr/bin/env python
+from setuptools import setup, Command
 
-from setuptools import setup
+
+class RunTests(Command):
+
+    user_options = []
+
+    def initialize_options(self):
+        pass
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        import subprocess
+        import sys
+
+        errno = subprocess.call(['py.test'])
+        raise SystemExit(errno)
+
 
 setup(
     name='NearPy',
@@ -27,4 +45,12 @@ setup(
         "bitarray",
         "future",
     ],
+    tests_require=[
+        "pytest",
+        "redis",
+        "mockredispy",
+    ],
+    cmdclass = {
+        'test': RunTests
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -1,24 +1,9 @@
 #!/usr/bin/env python
-from setuptools import setup, Command
+import sys
+from setuptools import setup
 
-
-class RunTests(Command):
-
-    user_options = []
-
-    def initialize_options(self):
-        pass
-
-    def finalize_options(self):
-        pass
-
-    def run(self):
-        import subprocess
-        import sys
-
-        errno = subprocess.call(['py.test'])
-        raise SystemExit(errno)
-
+needs_pytest = {'pytest', 'test', 'ptr'}.intersection(sys.argv)
+setup_requires = ['pytest-runner>=2.0,<3.0'] if needs_pytest else []
 
 setup(
     name='NearPy',
@@ -45,12 +30,10 @@ setup(
         "bitarray",
         "future",
     ],
+    setup_requires=setup_requires,
     tests_require=[
         "pytest",
         "redis",
         "mockredispy",
-    ],
-    cmdclass = {
-        'test': RunTests
-    },
+    ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,13 @@
+[tox]
+envlist = {py27,py33,py34}
+
+[pytest]
+testpaths = nearpy/tests
+python_files = *_tests.py
+
+[testenv]
+recreate = false
+usedevelop = true
+skipsdist = true
+commands =
+    python setup.py test


### PR DESCRIPTION
TravisCI build results: https://travis-ci.org/akabos/NearPy

Run tests locally:

```
$ python setup.py test
```

or 

```
$ pip install pytest
$ py.test 
```

or 

```
$ pip install pytest
$ python run_tests.py
```


Run for multiple python versions:

```
$ pip install tox
$ tox -e py27,py34
```