### PR TITLE
Move the steps in the neighbour search to their own methods

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup_requires = ['pytest-runner>=2.0,<3.0'] if needs_pytest else []
 
 setup(
     name='NearPy',
-    version='0.2.2',
+    version='0.2.3',
     author='Ole Krause-Sparmann',
     author_email='ole@pixelogik.de',
     packages=[


### PR DESCRIPTION
We are working on a batched implementation of the hashing functions to allow for multiple random projections to be applied at the same time. In order to implement this, I need to be able to override the implementations of the steps in the neighbor search, but don't want to simply duplicate it.

I therefore moved the steps to their own methods. This also lead to less duplication.