### PR TITLE
candidate_count missing parameter, parentheses and xrange 

### DIFF
--- a/nearpy/engine.py
+++ b/nearpy/engine.py
@@ -111,7 +111,7 @@ class Engine(object):
         has less entries (increase projection count for example).
         """
         # Collect candidates from all buckets from all hashes
-        candidates = self._get_candidates()
+        candidates = self._get_candidates(v)
         return len(candidates)
 
     def neighbours(self, v):

--- a/nearpy/examples/example1.py
+++ b/nearpy/examples/example1.py
@@ -37,7 +37,7 @@ def example1():
     # Number of data points (dont do too much because of exact search)
     POINTS = 10000
 
-    print 'Creating engines'
+    print('Creating engines')
 
     # We want 12 projections, 20 results at least
     rbpt = RandomBinaryProjectionTree('rbpt', 20, 20)
@@ -76,7 +76,7 @@ def example1():
     # Create engine 3
     engine_perm2 = Engine(DIM, lshashes=[permutations2], distance=CosineDistance())
 
-    print 'Indexing %d random vectors of dimension %d' % (POINTS, DIM)
+    print('Indexing %d random vectors of dimension %d' % (POINTS, DIM))
 
     # First index some random vectors
     matrix = numpy.zeros((POINTS,DIM))
@@ -88,53 +88,53 @@ def example1():
         engine_perm.store_vector(v)
         engine_perm2.store_vector(v)
 
-    print 'Buckets 1 = %d' % len(engine.storage.buckets['rbp1'].keys())
-    print 'Buckets 2 = %d' % len(engine_rbpt.storage.buckets['rbpt'].keys())
+    print('Buckets 1 = %d' % len(engine.storage.buckets['rbp1'].keys()))
+    print('Buckets 2 = %d' % len(engine_rbpt.storage.buckets['rbpt'].keys()))
 
-    print 'Building permuted index for HashPermutations'
+    print('Building permuted index for HashPermutations')
 
     # Then update permuted index
     permutations.build_permuted_index()
 
-    print 'Generate random data'
+    print('Generate random data')
 
     # Get random query vector
     query = numpy.random.randn(DIM)
 
     # Do random query on engine 1
-    print '\nNeighbour distances with RandomBinaryProjectionTree:'
-    print '  -> Candidate count is %d' % engine_rbpt.candidate_count(query)
+    print('\nNeighbour distances with RandomBinaryProjectionTree:')
+    print('  -> Candidate count is %d' % engine_rbpt.candidate_count(query))
     results = engine_rbpt.neighbours(query)
     dists = [x[2] for x in results]
-    print dists
+    print(dists)
 
     # Do random query on engine 2
-    print '\nNeighbour distances with RandomBinaryProjections:'
-    print '  -> Candidate count is %d' % engine.candidate_count(query)
+    print('\nNeighbour distances with RandomBinaryProjections:')
+    print('  -> Candidate count is %d' % engine.candidate_count(query))
     results = engine.neighbours(query)
     dists = [x[2] for x in results]
-    print dists
+    print(dists)
 
     # Do random query on engine 3
-    print '\nNeighbour distances with HashPermutations:'
-    print '  -> Candidate count is %d' % engine_perm.candidate_count(query)
+    print('\nNeighbour distances with HashPermutations:')
+    print('  -> Candidate count is %d' % engine_perm.candidate_count(query))
     results = engine_perm.neighbours(query)
     dists = [x[2] for x in results]
-    print dists
+    print(dists)
 
     # Do random query on engine 4
-    print '\nNeighbour distances with HashPermutations2:'
-    print '  -> Candidate count is %d' % engine_perm2.candidate_count(query)
+    print('\nNeighbour distances with HashPermutations2:')
+    print('  -> Candidate count is %d' % engine_perm2.candidate_count(query))
     results = engine_perm2.neighbours(query)
     dists = [x[2] for x in results]
-    print dists
+    print(dists)
 
     # Real neighbours
-    print '\nReal neighbour distances:'
+    print('\nReal neighbour distances:')
     query = query.reshape((1,DIM))
     dists = CosineDistance().distance(matrix,query)
     dists = dists.reshape((-1,))
     dists = sorted(dists)
-    print dists[:10]
+    print(dists[:10])
 
 

--- a/nearpy/examples/example2.py
+++ b/nearpy/examples/example2.py
@@ -40,7 +40,7 @@ def example2():
 
     ##########################################################
 
-    print 'Performing indexing with HashPermutations...'
+    print('Performing indexing with HashPermutations...')
     t0 = time.time()
 
     # Create permutations meta-hash
@@ -58,7 +58,7 @@ def example2():
 
     # First index some random vectors
     matrix = numpy.zeros((POINTS,DIM))
-    for i in xrange(POINTS):
+    for i in range(POINTS):
         v = numpy.random.randn(DIM)
         matrix[i] = v
         engine_perm.store_vector(v)
@@ -67,29 +67,29 @@ def example2():
     permutations.build_permuted_index()
 
     t1 = time.time()
-    print 'Indexing took %f seconds' % (t1-t0)
+    print('Indexing took %f seconds' % (t1-t0))
 
     # Get random query vector
     query = numpy.random.randn(DIM)
 
     # Do random query on engine 3
-    print '\nNeighbour distances with HashPermutations:'
-    print '  -> Candidate count is %d' % engine_perm.candidate_count(query)
+    print('\nNeighbour distances with HashPermutations:')
+    print('  -> Candidate count is %d' % engine_perm.candidate_count(query))
     results = engine_perm.neighbours(query)
     dists = [x[2] for x in results]
-    print dists
+    print(dists)
 
     # Real neighbours
-    print '\nReal neighbour distances:'
+    print('\nReal neighbour distances:')
     query = query.reshape((DIM))
     dists = CosineDistance().distance(matrix, query)
     dists = dists.reshape((-1,))
     dists = sorted(dists)
-    print dists[:10]
+    print(dists[:10])
 
     ##########################################################
 
-    print '\nPerforming indexing with HashPermutationMapper...'
+    print('\nPerforming indexing with HashPermutationMapper...')
     t0 = time.time()
 
     # Create permutations meta-hash
@@ -106,35 +106,35 @@ def example2():
 
     # First index some random vectors
     matrix = numpy.zeros((POINTS,DIM))
-    for i in xrange(POINTS):
+    for i in range(POINTS):
         v = numpy.random.randn(DIM)
         matrix[i] = v
         engine_perm2.store_vector(v)
 
     t1 = time.time()
-    print 'Indexing took %f seconds' % (t1-t0)
+    print('Indexing took %f seconds' % (t1-t0))
 
     # Get random query vector
     query = numpy.random.randn(DIM)
 
     # Do random query on engine 4
-    print '\nNeighbour distances with HashPermutationMapper:'
-    print '  -> Candidate count is %d' % engine_perm2.candidate_count(query)
+    print('\nNeighbour distances with HashPermutationMapper:')
+    print('  -> Candidate count is %d' % engine_perm2.candidate_count(query))
     results = engine_perm2.neighbours(query)
     dists = [x[2] for x in results]
-    print dists
+    print(dists)
 
     # Real neighbours
-    print '\nReal neighbour distances:'
+    print('\nReal neighbour distances:')
     query = query.reshape((DIM))
     dists = CosineDistance().distance(matrix,query)
     dists = dists.reshape((-1,))
     dists = sorted(dists)
-    print dists[:10]
+    print(dists[:10])
 
     ##########################################################
 
-    print '\nPerforming indexing with mutliple binary hashes...'
+    print('\nPerforming indexing with multiple binary hashes...')
     t0 = time.time()
 
     hashes = []
@@ -146,30 +146,30 @@ def example2():
 
     # First index some random vectors
     matrix = numpy.zeros((POINTS,DIM))
-    for i in xrange(POINTS):
+    for i in range(POINTS):
         v = numpy.random.randn(DIM)
         matrix[i] = v
         engine_rbps.store_vector(v)
 
     t1 = time.time()
-    print 'Indexing took %f seconds' % (t1-t0)
+    print('Indexing took %f seconds' % (t1-t0))
 
     # Get random query vector
     query = numpy.random.randn(DIM)
 
     # Do random query on engine 4
-    print '\nNeighbour distances with mutliple binary hashes:'
-    print '  -> Candidate count is %d' % engine_rbps.candidate_count(query)
+    print('\nNeighbour distances with multiple binary hashes:')
+    print('  -> Candidate count is %d' % engine_rbps.candidate_count(query))
     results = engine_rbps.neighbours(query)
     dists = [x[2] for x in results]
-    print dists
+    print(dists)
 
     # Real neighbours
-    print '\nReal neighbour distances:'
+    print('\nReal neighbour distances:')
     query = query.reshape((DIM))
     dists = CosineDistance().distance(matrix,query)
     dists = dists.reshape((-1,))
     dists = sorted(dists)
-    print dists[:10]
+    print(dists[:10])
 
     ##########################################################


### PR DESCRIPTION
`candidate_count` was calling `_get_candidates` without parameter.
I added parentheses around `print`'s arguments.
I replaced `xrange` with `range` (only in the example files, so I don't think it's a big concern, but python 3 doesn't have `xrange`).

Cheers!