### PR TITLE
add Engine.store_many_vectors() for uploading to Redis using pipeline

### DIFF
--- a/nearpy/engine.py
+++ b/nearpy/engine.py
@@ -96,6 +96,21 @@ class Engine(object):
                 self.storage.store_vector(lshash.hash_name, bucket_key,
                                           nv, data)
 
+    def store_many_vectors(self, vs, data=None):
+        """
+        Store a batch of vectors in Redis. 
+        Hashes vector v and stores it in all matching buckets in the storage.
+        The data argument must be JSON-serializable. It is stored with the
+        vector and will be returned in search results.
+        """
+        # We will store the normalized vector (used during retrieval)
+        nvs = [unitvec(i) for i in vs]
+        # Store vector in each bucket of all hashes
+        for lshash in self.lshashes:
+            bucket_keys = [lshash.hash_vector(i)[0] for i in vs]
+            self.storage.store_many_vectors(lshash.hash_name, bucket_keys,
+                                            nvs, data)
+
     def delete_vector(self, data, v=None):
         """
         Deletes vector v and his id (data) in all matching buckets in the storage.


### PR DESCRIPTION
Add store_many_vectors() method for RedisStorage(). This method uses redis.pipeline() to store key-values in a batch. With this method, the speed of storing hashes is significantly increased for problems with a large amount of hashes. 

This method has been applied well in my project where the number of hashes is around 3000. 