### PR TITLE
Revert "add Engine.store_many_vectors() for uploading to Redis using pipeline"

### DIFF
--- a/nearpy/engine.py
+++ b/nearpy/engine.py
@@ -96,21 +96,6 @@ class Engine(object):
                 self.storage.store_vector(lshash.hash_name, bucket_key,
                                           nv, data)
 
-    def store_many_vectors(self, vs, data=None):
-        """
-        Store a batch of vectors in Redis. 
-        Hashes vector v and stores it in all matching buckets in the storage.
-        The data argument must be JSON-serializable. It is stored with the
-        vector and will be returned in search results.
-        """
-        # We will store the normalized vector (used during retrieval)
-        nvs = [unitvec(i) for i in vs]
-        # Store vector in each bucket of all hashes
-        for lshash in self.lshashes:
-            bucket_keys = [lshash.hash_vector(i)[0] for i in vs]
-            self.storage.store_many_vectors(lshash.hash_name, bucket_keys,
-                                            nvs, data)
-
     def delete_vector(self, data, v=None):
         """
         Deletes vector v and his id (data) in all matching buckets in the storage.

--- a/nearpy/storage/storage_redis.py
+++ b/nearpy/storage/storage_redis.py
@@ -85,49 +85,6 @@ class RedisStorage(Storage):
         # Push JSON representation of dict to end of bucket list
         self.redis_object.rpush(redis_key, pickle.dumps(val_dict, protocol=2))
 
-    def store_many_vectors(self, hash_name, bucket_keys, vs, data):
-        """
-        Store a batch of vectors in Redis.
-        Stores vector and JSON-serializable data in bucket with specified key.
-        """
-        with self.redis_object.pipeline() as pipeline:
-            for idx, v in enumerate(vs):
-                redis_key = self._format_redis_key(hash_name, bucket_keys[idx])
-                val_dict = {}
-
-                # Depending on type (sparse or not) fill value dict
-                if scipy.sparse.issparse(v):
-                    # Make sure that we are using COO format (easy to handle)
-                    if not scipy.sparse.isspmatrix_coo(v):
-                        v = scipy.sparse.coo_matrix(v)
-
-                    # Construct list of [index, value] items,
-                    # one for each non-zero element of the sparse vector
-                    encoded_values = []
-
-                    for k in range(v.data.size):
-                        row_index = v.row[k]
-                        value = v.data[k]
-                        encoded_values.append([int(row_index), value])
-
-                    val_dict['sparse'] = 1
-                    val_dict['nonzeros'] = encoded_values
-                    val_dict['dim'] = v.shape[0]
-                else:
-                    # Make sure it is a 1d vector
-                    v = numpy.reshape(v, v.shape[0])
-                    val_dict['vector'] = v.tostring()
-
-                val_dict['dtype'] = v.dtype.name
-
-                # Add data if set
-                if data is not None:
-                    val_dict['data'] = data[idx]
-
-                # Push JSON representation of dict to end of bucket list
-                pipeline.rpush(redis_key, pickle.dumps(val_dict, protocol=2))
-            pipeline.execute()
-
     def _format_redis_key(self, hash_name, bucket_key):
         return '{}{}'.format(self._format_hash_prefix(hash_name), bucket_key)
 


### PR DESCRIPTION
@xieqihui I snap. Same case as in the Mongo pull request. You added a new method to the Redis storage class. All storage class should support the same methods, if possible. A user of the Engine class could use the store_many_vectors method, even when not using the Redis storage, which will crash. I would like to keep the usage of Engine as simple as possible. 

My suggestion is: In Engine differentiate in store_many_vectors between the Redis case and others. If it is not a Redis storage, use the store_vector method in a loop so that it also works there. 


