### PR TITLE
docs: fix a few simple typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ clean_buckets(self, hash_name)
 ```
 ## Hashes
 
-All LSH implementatiosn in NearPy do subclass nearpy.hashes.LSHash, which has one main method, besides
+All LSH implementation in NearPy do subclass nearpy.hashes.LSHash, which has one main method, besides
 constructor and reset methods.
 
 ```python

--- a/nearpy/filters/uniquefilter.py
+++ b/nearpy/filters/uniquefilter.py
@@ -29,7 +29,7 @@ from nearpy.filters.vectorfilter import VectorFilter
 class UniqueFilter(VectorFilter):
     """
     Makes sure that each vectors is only once in the vector list. Works on
-    both types of vector listst - (vector, data, distance) and
+    both types of vector lists - (vector, data, distance) and
     (vector, data).
 
     This filter uses the 'data' as key for uniqueness. If you need some

--- a/nearpy/filters/vectorfilter.py
+++ b/nearpy/filters/vectorfilter.py
@@ -24,7 +24,7 @@
 class VectorFilter(object):
     """
     Interface for vector-list filters. They get either (vector, data, distance)
-    tupes or (vector, data) tuples and return subsets of them.
+    tuples or (vector, data) tuples and return subsets of them.
 
     Some filters work on lists of (vector, data, distance) tuples, others work
     on lists of (vector, data) tuples and others work on both types.

--- a/nearpy/hashes/permutation/hashpermutationmapper.py
+++ b/nearpy/hashes/permutation/hashpermutationmapper.py
@@ -32,7 +32,7 @@ class HashPermutationMapper(LSHash):
 
     You use this just like every other LSHash implementation and
     add the actual binary hashes you want to use via the add_child_hash
-    method. Each child hash will be used separatly.
+    method. Each child hash will be used separately.
 
     So to use this you have to do the following steps:
 
@@ -88,7 +88,7 @@ class HashPermutationMapper(LSHash):
                 for bucket_key in lshash.hash_vector(v, querying):
                     # Get permuted keys
                     perm_keys = self.permuted_keys(bucket_key)
-                    # Put extact hit key into list
+                    # Put exact hit key into list
                     perm_keys.append(bucket_key)
 
                     # Append key for storage (not the permutations)

--- a/nearpy/hashes/permutation/hashpermutations.py
+++ b/nearpy/hashes/permutation/hashpermutations.py
@@ -33,7 +33,7 @@ class HashPermutations(LSHash):
     This meta-hash performs hash permutations on binary bucket keys.
     You use this just like every other LSHash implementation and
     add the actual binary hashes you want to use via the add_child_hash
-    method. Each child hash will be used separatly.
+    method. Each child hash will be used separately.
 
     After all vectors have been indexed you have to call build_permuted_index
     to generate the permuted index.

--- a/nearpy/hashes/permutation/permutedIndex.py
+++ b/nearpy/hashes/permutation/permutedIndex.py
@@ -53,7 +53,7 @@ class PermutedIndex:
     and we want to find the 1-neighbour of '00001'.
 
     If we just sort the original list, i.e. ['00001','00011','00111','01111','10000'],
-    the 1-neighbour of '00001' in the sorted list, '00011', is not the cloest neighbour
+    the 1-neighbour of '00001' in the sorted list, '00011', is not the closest neighbour
     in term of Hamming distance.
 
     Here's an approximate solution:
@@ -141,7 +141,7 @@ class PermutedIndex:
             topk = topk.union(set(candidates))
         topk = list(topk)
 
-        # sort the topk neighbour keys according to the Hamming distance to qurey key
+        # sort the topk neighbour keys according to the Hamming distance to query key
         topk = sorted(topk, key=lambda x: self.hamming_distance(x, query_key))
         # return the top k items
         topk_bin = [x.to01() for x in topk[:k]]

--- a/nearpy/hashes/randombinaryprojectiontree.py
+++ b/nearpy/hashes/randombinaryprojectiontree.py
@@ -48,7 +48,7 @@ class RandomBinaryProjectionTreeNode(object):
         if tree_depth < len(bucket_key):
             hash_char = bucket_key[tree_depth]
 
-            # This is not the leaf so continue down into the tree towards the leafes
+            # This is not the leaf so continue down into the tree towards the leaves
 
             #print 'hash_char=%c' % hash_char
 


### PR DESCRIPTION
There are small typos in:
- README.md
- nearpy/filters/uniquefilter.py
- nearpy/filters/vectorfilter.py
- nearpy/hashes/permutation/hashpermutationmapper.py
- nearpy/hashes/permutation/hashpermutations.py
- nearpy/hashes/permutation/permutedIndex.py
- nearpy/hashes/randombinaryprojectiontree.py

Fixes:
- Should read `separately` rather than `separatly`.
- Should read `tuples` rather than `tupes`.
- Should read `query` rather than `qurey`.
- Should read `lists` rather than `listst`.
- Should read `leaves` rather than `leafes`.
- Should read `implementation` rather than `implementatiosn`.
- Should read `exact` rather than `extact`.
- Should read `closest` rather than `cloest`.

Closes #94